### PR TITLE
The connection string no longer needs to be in the key vault prior to…

### DIFF
--- a/src/Dnn.KeyMaster.API/Utilities/SecretsProvider.cs
+++ b/src/Dnn.KeyMaster.API/Utilities/SecretsProvider.cs
@@ -21,9 +21,16 @@ namespace Dnn.KeyMaster.API.Utilities
         {
             try
             {
-                var connectionString = GetConnectionString(secrets);
+                var testSecret = "DNN--KEYMASTER--VALIDATION--TEST";
+                var testSecretValue = testSecret + "VALUE";
+                CreateOrUpdateAppSetting(testSecret, testSecretValue, false);
+                
+                if (!DeleteAppSetting(testSecret, false))
+                {
+                    throw new Exception("Unable to validate secrets");
+                }
 
-                return !string.IsNullOrWhiteSpace(connectionString);
+                return true;
             }
             catch (Exception ex)
             {
@@ -31,7 +38,7 @@ namespace Dnn.KeyMaster.API.Utilities
                 return false;
             }
         }
-
+        
         internal static string GetConnectionString(Secrets secrets = null)
         {
             return Configuration.AppSettingsProvider.Instance.KeyMaster.GetConnectionString(secrets?.ToNameValueCollection());
@@ -47,14 +54,14 @@ namespace Dnn.KeyMaster.API.Utilities
             return Configuration.AppSettingsProvider.Instance[key];
         }
 
-        internal static bool DeleteAppSetting(string key)
+        internal static bool DeleteAppSetting(string key, bool updateAppSettings = true)
         {            
-            return Configuration.AppSettingsProvider.Instance.KeyMaster.DeleteSecret(key);
+            return Configuration.AppSettingsProvider.Instance.KeyMaster.DeleteSecret(key, updateAppSettings);
         }
 
-        internal static bool CreateOrUpdateAppSetting(string key, string value)
+        internal static bool CreateOrUpdateAppSetting(string key, string value, bool updateAppSettings = true)
         {
-            return Configuration.AppSettingsProvider.Instance.KeyMaster.CreateOrUpdate(key, value);
+            return Configuration.AppSettingsProvider.Instance.KeyMaster.CreateOrUpdate(key, value, updateAppSettings);
         }
 
         internal static Secrets GetConfiguration()

--- a/src/Dnn.KeyMaster.Configuration/IKeyMasterAppSettings.cs
+++ b/src/Dnn.KeyMaster.Configuration/IKeyMasterAppSettings.cs
@@ -7,8 +7,8 @@ namespace Dnn.KeyMaster.Configuration
     {
         NameValueCollection GetAppSettings();
         string GetSecret(string key);
-        bool DeleteSecret(string key);
-        bool CreateOrUpdate(string key, string value);
+        bool DeleteSecret(string key, bool updateAppsettings = true);
+        bool CreateOrUpdate(string key, string value, bool updateAppsettings = true);
         string GetConnectionString(NameValueCollection secrets = null);
     }
 }


### PR DESCRIPTION
… configuring. The extension handles creation of the connection string and removal when you toggle the key master on/off

closes: #57 